### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -63,7 +63,7 @@ def _divideNum(num):
     if num < 0 or num - 1e9 > 0:
         raise ValueError('num value should be 1~1e9')
 
-    strNum = '%015.2f' % num
+    strNum = '{0:015.2f}'.format(num)
 
     # 填写_integer
     for i in range(3):
@@ -157,7 +157,7 @@ if __name__ == '__main__':
     for case in test:
         try:
             result = convert(case).encode('utf-8')
-            print '%13r : %s' % (case, result)
+            print '{0:13!r} : {1!s}'.format(case, result)
         except ValueError, e:
             logging.exception(e)
         except TypeError, e:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:youyongsong:ArabicNum2RMB?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:youyongsong:ArabicNum2RMB?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
